### PR TITLE
Add app.kubernetes.io/instance label for flux logs

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -8,6 +8,8 @@ patches:
       kind: Deployment
       metadata:
         name: all
+        labels:
+          app.kubernetes.io/instance: flux-system
       spec:
         template:
           spec:


### PR DESCRIPTION
~weaveworks/flux2-openshift#4~ not related, I have mixed myself up, #4 was not meant to be about the logs issue.

(I do not quite know how to test this, but I have a feeling it's not going to work)