### PR TITLE
Fix release.sh script for newer Flux version

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ echo "Generating the manifests using the built CLI ..."
 manifest="manifests-$version.yaml"
 
 echo "Exporting gotk-components.yaml ..."
-docker run --rm -it ghcr.io/fluxcd/flux-cli:v${version} install --version="$version" \
+docker run --rm -it ghcr.io/fluxcd/flux-cli:v${version} install --version="v$version" \
   --components-extra=image-reflector-controller,image-automation-controller \
   --export > gotk-components.yaml
 


### PR DESCRIPTION
Flux 0.33 introduced version validation to the `install` command which
as a side effect makes the `v` prefix to the `--version` flag value
mandatory. The release.sh script now does that.

This change is backwards-compatible as older version of the Flux CLI
work with the `v` prefix, too.
