### PR TITLE
Don't use `--version` flag in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ echo "Generating the manifests using the built CLI ..."
 manifest="manifests-$version.yaml"
 
 echo "Exporting gotk-components.yaml ..."
-docker run --rm -it ghcr.io/fluxcd/flux-cli:v${version} install --version="v$version" \
+docker run --rm -it ghcr.io/fluxcd/flux-cli:v${version} install \
   --components-extra=image-reflector-controller,image-automation-controller \
   --export > gotk-components.yaml
 


### PR DESCRIPTION
I changed the script not pass the `--version` flag at all so that it
now always uses the embedded manifests. Passing in the version is
unnecessary as the version is mandated by the image tag, anyway.

refs #13
